### PR TITLE
Add inputmode="numeric" to number inputs for mobile keypad

### DIFF
--- a/src/components/NumberInput.js
+++ b/src/components/NumberInput.js
@@ -23,6 +23,8 @@ export function renderNumberInput(value, activeSystem) {
       <div class="flex gap-3">
         <input
           type="number"
+          inputmode="numeric"
+          pattern="[0-9]*"
           id="number-input"
           value="${value}"
           placeholder="Enter a number..."

--- a/src/components/QuizView.js
+++ b/src/components/QuizView.js
@@ -166,7 +166,7 @@ export function renderQuizView() {
     if (!revealed) {
       answerArea = `
         <div class="flex gap-3">
-          <input type="number" id="quiz-guess" value="${esc(guess)}" placeholder="Your answer..."
+          <input type="number" inputmode="numeric" pattern="[0-9]*" id="quiz-guess" value="${esc(guess)}" placeholder="Your answer..."
             class="flex-1 px-4 py-3 bg-parchment-light/50 border-2 border-stone-300 rounded-lg
               font-crimson text-lg text-stone-800 placeholder-stone-400
               focus:outline-none focus:ring-2 focus:ring-stone-400" />


### PR DESCRIPTION
On mobile devices, type="number" alone doesn't always show a clean
numeric keypad. Adding inputmode="numeric" and pattern="[0-9]*"
ensures iOS and Android show the numeric-only keyboard for the main
number input and quiz guess input.

https://claude.ai/code/session_01JW2Rd41SYegf1XgCh6YMGe