### PR TITLE
Add Showcase mode with verified walkthroughs and Report system

### DIFF
--- a/src/components/ConversionDisplay.js
+++ b/src/components/ConversionDisplay.js
@@ -136,6 +136,11 @@ export function renderConversionDisplay(systemId, number) {
     </div>`;
   }
 
+  // Flatten result for display in report context
+  const resultText = Array.isArray(result[0])
+    ? result.map(g => g.join('')).join(' | ')
+    : result.join(' ');
+
   return `<div class="p-6 rounded-xl border-2 ${ac}">
     <div class="text-center mb-2">
       <span class="font-cinzel text-sm text-stone-500 uppercase tracking-wider">
@@ -143,5 +148,20 @@ export function renderConversionDisplay(systemId, number) {
       </span>
     </div>
     ${renderResult(system, result)}
+    <div class="flex items-center justify-center gap-3 mt-4 pt-3 border-t border-stone-200/50">
+      <button data-action="verify-conversion" data-system="${systemId}" data-number="${num}"
+        class="px-3 py-1.5 text-xs font-crimson text-stone-500 border border-stone-300 rounded-lg
+          hover:bg-stone-100 transition-colors flex items-center gap-1.5">
+        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+        Verify
+      </button>
+      <button data-action="report-open" data-system="${systemId}" data-system-name="${esc(system.name)}" data-number="${num}" data-result="${esc(resultText)}"
+        class="px-3 py-1.5 text-xs font-crimson text-stone-500 border border-stone-300 rounded-lg
+          hover:bg-stone-100 transition-colors flex items-center gap-1.5">
+        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"/></svg>
+        Report Issue
+      </button>
+      <div id="verify-result" class="text-xs font-crimson"></div>
+    </div>
   </div>`;
 }

--- a/src/components/ReportModal.js
+++ b/src/components/ReportModal.js
@@ -1,0 +1,53 @@
+function esc(str) {
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export function renderReportModal(context) {
+  const { systemName, number, result } = context;
+
+  return `
+    <div class="fixed inset-0 z-50 flex items-center justify-center p-4" id="report-overlay">
+      <div class="absolute inset-0 bg-black/40" data-action="report-close"></div>
+      <div class="relative bg-parchment rounded-xl shadow-xl max-w-md w-full p-6 space-y-4 animate-modalIn">
+        <div class="flex items-center justify-between">
+          <h3 class="font-cinzel text-lg text-stone-800">Report an Issue</h3>
+          <button data-action="report-close" class="text-stone-400 hover:text-stone-600 text-xl leading-none">&times;</button>
+        </div>
+
+        <div class="text-sm font-crimson text-stone-500 space-y-1">
+          <p>System: <strong class="text-stone-700">${esc(systemName)}</strong></p>
+          <p>Number: <strong class="text-stone-700">${esc(String(number))}</strong></p>
+          <p>Result: <strong class="text-stone-700">${esc(result)}</strong></p>
+        </div>
+
+        <div class="space-y-3">
+          <label class="block">
+            <span class="font-crimson text-sm text-stone-600">Issue type</span>
+            <select id="report-type"
+              class="mt-1 w-full px-3 py-2 bg-white border border-stone-300 rounded-lg
+                font-crimson text-stone-800 focus:outline-none focus:ring-2 focus:ring-stone-400">
+              <option value="incorrect-result">Incorrect conversion result</option>
+              <option value="wrong-explanation">Wrong step explanation</option>
+              <option value="rendering-issue">Rendering / display issue</option>
+              <option value="other">Other</option>
+            </select>
+          </label>
+          <label class="block">
+            <span class="font-crimson text-sm text-stone-600">Details (optional)</span>
+            <textarea id="report-details" rows="3" placeholder="Describe the issue..."
+              class="mt-1 w-full px-3 py-2 bg-white border border-stone-300 rounded-lg
+                font-crimson text-stone-800 placeholder-stone-400 resize-none
+                focus:outline-none focus:ring-2 focus:ring-stone-400"></textarea>
+          </label>
+        </div>
+
+        <div class="flex justify-end gap-3">
+          <button data-action="report-close"
+            class="px-4 py-2 font-cinzel text-sm text-stone-600 hover:text-stone-800 transition-colors">Cancel</button>
+          <button data-action="report-submit"
+            class="px-5 py-2 bg-stone-700 text-parchment-light font-cinzel text-sm
+              rounded-lg hover:bg-stone-600 transition-colors shadow-md">Submit Report</button>
+        </div>
+      </div>
+    </div>`;
+}

--- a/src/components/ReportsPanel.js
+++ b/src/components/ReportsPanel.js
@@ -1,0 +1,80 @@
+const STORAGE_KEY = 'ancient-number-converter-reports';
+
+function esc(str) {
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export function getReports() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+  } catch {
+    return [];
+  }
+}
+
+export function saveReport(report) {
+  const reports = getReports();
+  reports.push({ ...report, id: Date.now(), timestamp: new Date().toISOString() });
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(reports));
+}
+
+export function deleteReport(id) {
+  const reports = getReports().filter(r => r.id !== id);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(reports));
+}
+
+export function exportReports() {
+  const reports = getReports();
+  if (reports.length === 0) return '';
+
+  const lines = ['Ancient Number Converter — Issue Reports', '='.repeat(45), ''];
+  for (const r of reports) {
+    lines.push(`[${r.timestamp}] ${r.systemName} — ${r.number}`);
+    lines.push(`  Type: ${r.type}`);
+    lines.push(`  Result: ${r.result}`);
+    if (r.details) lines.push(`  Details: ${r.details}`);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+const typeLabels = {
+  'incorrect-result': 'Incorrect result',
+  'wrong-explanation': 'Wrong explanation',
+  'rendering-issue': 'Rendering issue',
+  'other': 'Other',
+};
+
+export function renderReportsPanel() {
+  const reports = getReports();
+
+  const listHtml = reports.length === 0
+    ? '<p class="font-crimson text-stone-400 italic text-center py-6">No reports submitted yet.</p>'
+    : reports.map(r => `
+        <div class="flex items-start gap-3 p-3 bg-white/50 rounded-lg border border-stone-200">
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+              <span class="font-cinzel text-sm text-stone-800">${esc(r.systemName)}</span>
+              <span class="font-crimson text-xs text-stone-400">#${esc(String(r.number))}</span>
+              <span class="px-1.5 py-0.5 text-xs font-crimson bg-stone-100 text-stone-500 rounded">${esc(typeLabels[r.type] || r.type)}</span>
+            </div>
+            ${r.details ? `<p class="font-crimson text-sm text-stone-600 mt-1 truncate">${esc(r.details)}</p>` : ''}
+            <p class="font-crimson text-xs text-stone-400 mt-1">${new Date(r.timestamp).toLocaleString()}</p>
+          </div>
+          <button data-action="report-delete" data-report-id="${r.id}"
+            class="text-stone-400 hover:text-red-500 transition-colors text-lg leading-none shrink-0"
+            title="Delete report">&times;</button>
+        </div>`).join('');
+
+  return `
+    <div class="space-y-4" id="reports-panel">
+      <div class="flex items-center justify-between">
+        <h3 class="font-cinzel text-sm text-stone-600 uppercase tracking-wider">Submitted Reports (${reports.length})</h3>
+        ${reports.length > 0 ? `
+          <button data-action="reports-export"
+            class="px-3 py-1 text-xs font-crimson text-stone-500 border border-stone-300 rounded-lg
+              hover:bg-stone-100 transition-colors">Export All</button>` : ''}
+      </div>
+      <div class="space-y-2">${listHtml}</div>
+    </div>`;
+}

--- a/src/components/ShowcaseView.js
+++ b/src/components/ShowcaseView.js
@@ -1,0 +1,223 @@
+import numberSystems from '../data/numberSystems.js';
+import showcaseExamples from '../data/showcaseExamples.js';
+import historicalContent from '../data/historicalContent.js';
+import { verifyRoundTrip } from '../utils/verification.js';
+
+const accentClasses = {
+  jungle: 'border-jungle/30 bg-gradient-to-b from-green-50/50 to-green-100/30',
+  amber: 'border-amber/30 bg-gradient-to-b from-amber-50/50 to-amber-100/30',
+  clay: 'border-clay/30 bg-gradient-to-b from-yellow-50/50 to-yellow-100/30',
+  imperial: 'border-imperial/30 bg-gradient-to-b from-purple-50/50 to-purple-100/30',
+  vermilion: 'border-vermilion/30 bg-gradient-to-b from-red-50/50 to-red-100/30',
+  mediterranean: 'border-mediterranean/30 bg-gradient-to-b from-blue-50/50 to-blue-100/30',
+  inca: 'border-inca/30 bg-gradient-to-b from-orange-50/50 to-orange-100/30',
+};
+
+const symbolClasses = {
+  jungle: 'border-jungle/40 bg-green-50',
+  amber: 'border-amber/40 bg-amber-50',
+  clay: 'border-clay/40 bg-yellow-50',
+  imperial: 'border-imperial/40 bg-purple-50 font-cinzel text-purple-900',
+  vermilion: 'border-vermilion/40 bg-red-50',
+  mediterranean: 'border-mediterranean/40 bg-blue-50 font-cinzel text-blue-900',
+  inca: 'border-inca/40 bg-orange-50',
+};
+
+function esc(str) {
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function renderCordCompact(result) {
+  const placeLabels = ['ones', 'tens', 'hundreds', 'thousands', 'ten-thousands'];
+  const displayed = [...result].reverse();
+  const cord = '<div class="absolute inset-y-0 left-1/2 -translate-x-1/2 w-1 bg-inca/50"></div>';
+  const rows = [];
+  rows.push(`<div class="relative w-32 h-3 flex justify-center items-center">${cord}<div class="relative z-10 w-8 h-1.5 rounded-sm bg-inca/60"></div></div>`);
+  for (let i = 0; i < displayed.length; i++) {
+    rows.push(`<div class="relative w-32 h-2">${cord}</div>`);
+    const sym = displayed[i];
+    const posIdx = displayed.length - 1 - i;
+    const label = placeLabels[posIdx] || '';
+    const isZero = sym === '\u2014';
+    if (isZero) {
+      rows.push(`<div class="flex items-center"><div class="relative w-32 h-4 flex justify-center items-center">${cord}<div class="relative z-10 w-4 border-t border-dashed border-inca/30"></div></div><span class="pl-2 font-crimson text-xs text-stone-400">${label}</span></div>`);
+    } else {
+      rows.push(`<div class="flex items-center"><div class="relative w-32 flex justify-center items-center py-1">${cord}<div class="relative z-10 flex items-center text-sm text-stone-800">${[...sym].map(k => `<span>${k}</span>`).join('')}</div></div><span class="pl-2 font-crimson text-xs text-stone-400">${label}</span></div>`);
+    }
+  }
+  rows.push(`<div class="relative w-32 h-3">${cord}</div>`);
+  return `<div class="flex justify-center"><div class="flex flex-col">${rows.join('')}</div></div>`;
+}
+
+function renderResult(system, result) {
+  const sc = symbolClasses[system.color];
+
+  if (system.renderMode === 'cord') {
+    return renderCordCompact(result);
+  }
+
+  if (system.renderMode === 'vertical') {
+    const items = [...result].reverse().map(sym =>
+      `<div class="h-12 w-12 flex items-center justify-center border-2 rounded-lg text-xl ${sc}">${esc(sym)}</div>`
+    ).join('');
+    return `<div class="flex justify-center"><div class="space-y-1">${items}</div></div>`;
+  }
+
+  if (system.renderMode === 'grouped') {
+    const groups = result.map(group => {
+      const syms = group.map(sym =>
+        `<div class="h-12 min-w-9 px-1.5 flex items-center justify-center border-2 rounded-lg text-xl ${sc}">${esc(sym)}</div>`
+      ).join('');
+      return `<div class="flex space-x-1">${syms}</div>`;
+    }).join('');
+    return `<div class="flex flex-col items-center space-y-2">${groups}</div>`;
+  }
+
+  const items = result.map(sym =>
+    `<div class="h-12 min-w-10 px-2 flex items-center justify-center border-2 rounded-lg text-xl ${sc}">${esc(sym)}</div>`
+  ).join('');
+  return `<div class="flex flex-wrap justify-center gap-1.5">${items}</div>`;
+}
+
+function renderVerifyBadge(systemId, number) {
+  const v = verifyRoundTrip(systemId, number);
+  if (v.passed) {
+    return `<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-crimson bg-green-100 text-green-700 border border-green-200" title="Round-trip verified: ${number} → ancient → ${v.parsed}">
+      <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+      Verified</span>`;
+  }
+  return `<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-crimson bg-red-100 text-red-700 border border-red-200" title="Verification failed: ${v.error}">
+    <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/></svg>
+    Failed</span>`;
+}
+
+function renderExampleCard(systemId, system, example, index) {
+  const { number, highlight } = example;
+  const { result, steps } = system.convert(number);
+  const ac = accentClasses[system.color];
+
+  const stepsHtml = (steps && steps.length > 0)
+    ? steps.map((step, i) => `
+        <div class="flex items-center gap-3 px-3 py-1.5 bg-white/50 rounded-lg border border-stone-200">
+          <span class="font-crimson text-stone-400 text-xs w-5 text-right">${i + 1}.</span>
+          <span class="text-lg min-w-7 text-center">${esc(step.symbol)}</span>
+          <span class="font-crimson text-stone-600 text-sm">${esc(step.explanation)}</span>
+        </div>`).join('')
+    : '';
+
+  return `
+    <div class="p-5 rounded-xl border-2 ${ac} space-y-3 showcase-card print-avoid-break">
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <span class="font-cinzel text-lg text-stone-800">${number.toLocaleString()}</span>
+          <p class="font-crimson text-sm text-stone-500 italic">${esc(highlight)}</p>
+        </div>
+        ${renderVerifyBadge(systemId, number)}
+      </div>
+      <div class="py-2">${renderResult(system, result)}</div>
+      ${stepsHtml ? `<div class="space-y-1.5">${stepsHtml}</div>` : ''}
+    </div>`;
+}
+
+export function renderShowcaseView(systemId) {
+  const system = numberSystems[systemId];
+  if (!system) return '';
+
+  const examples = showcaseExamples[systemId] || [];
+  const content = historicalContent[systemId];
+
+  const headerHtml = content ? `
+    <div class="p-5 rounded-xl border-2 border-stone-300 bg-white/40 space-y-3 print-avoid-break">
+      <h2 class="font-cinzel text-lg text-stone-800">${esc(system.name)} Numeral System</h2>
+      <p class="font-crimson text-stone-600">${esc(content.overview)}</p>
+      <div class="flex flex-wrap gap-3 text-xs font-crimson text-stone-500">
+        <span class="px-2 py-1 bg-stone-100 rounded">${esc(system.era)}</span>
+        <span class="px-2 py-1 bg-stone-100 rounded">${esc(system.region)}</span>
+        <span class="px-2 py-1 bg-stone-100 rounded">Base ${system.base}</span>
+        <span class="px-2 py-1 bg-stone-100 rounded">Range: ${system.range[0].toLocaleString()} – ${system.range[1].toLocaleString()}</span>
+      </div>
+    </div>` : '';
+
+  const cardsHtml = examples.map((ex, i) => renderExampleCard(systemId, system, ex, i)).join('');
+
+  const allVerified = examples.every(ex => verifyRoundTrip(systemId, ex.number).passed);
+  const summaryBadge = allVerified
+    ? `<span class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-crimson bg-green-100 text-green-700 border border-green-200">
+        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+        All ${examples.length} examples verified</span>`
+    : `<span class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-crimson bg-red-100 text-red-700 border border-red-200">
+        Some verifications failed</span>`;
+
+  return `
+    <div class="space-y-5" id="showcase-view">
+      ${headerHtml}
+      <div class="flex items-center justify-between flex-wrap gap-3">
+        ${summaryBadge}
+        <div class="flex gap-2">
+          <button data-action="showcase-print"
+            class="px-4 py-2 bg-stone-200 text-stone-700 font-cinzel text-sm rounded-lg
+              hover:bg-stone-300 transition-colors flex items-center gap-2">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/></svg>
+            Print
+          </button>
+          <button data-action="showcase-copy"
+            class="px-4 py-2 bg-stone-200 text-stone-700 font-cinzel text-sm rounded-lg
+              hover:bg-stone-300 transition-colors flex items-center gap-2">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/></svg>
+            Copy as Text
+          </button>
+        </div>
+      </div>
+      <div class="space-y-4">${cardsHtml}</div>
+    </div>`;
+}
+
+/**
+ * Serialize showcase to plain text for clipboard.
+ */
+export function serializeShowcase(systemId) {
+  const system = numberSystems[systemId];
+  if (!system) return '';
+
+  const examples = showcaseExamples[systemId] || [];
+  const content = historicalContent[systemId];
+  const lines = [];
+
+  lines.push(`${'='.repeat(50)}`);
+  lines.push(`${system.name} Numeral System — Showcase`);
+  lines.push(`${system.era} · ${system.region} · Base ${system.base}`);
+  lines.push(`Range: ${system.range[0].toLocaleString()} – ${system.range[1].toLocaleString()}`);
+  lines.push(`${'='.repeat(50)}`);
+
+  if (content) {
+    lines.push('');
+    lines.push(content.overview);
+  }
+
+  for (const ex of examples) {
+    lines.push('');
+    lines.push(`--- ${ex.number.toLocaleString()} ---`);
+    lines.push(ex.highlight);
+
+    const { result, steps } = system.convert(ex.number);
+    // Flatten result to text
+    const resultText = Array.isArray(result[0])
+      ? result.map(g => g.join('')).join(' | ')
+      : result.join(' ');
+    lines.push(`Result: ${resultText}`);
+
+    if (steps && steps.length > 0) {
+      lines.push('Steps:');
+      for (const step of steps) {
+        lines.push(`  ${step.symbol}  ${step.explanation}`);
+      }
+    }
+
+    const v = verifyRoundTrip(systemId, ex.number);
+    lines.push(v.passed ? `[VERIFIED] Round-trip: ${ex.number} → ${resultText} → ${v.parsed}` : `[FAILED] ${v.error}`);
+  }
+
+  lines.push('');
+  lines.push('Generated by Ancient Number Converter');
+  return lines.join('\n');
+}

--- a/src/converters/__tests__/verification.test.js
+++ b/src/converters/__tests__/verification.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { verifyRoundTrip } from '../../utils/verification.js';
+import showcaseExamples from '../../data/showcaseExamples.js';
+
+describe('Round-trip verification', () => {
+  for (const [systemId, examples] of Object.entries(showcaseExamples)) {
+    describe(systemId, () => {
+      for (const { number } of examples) {
+        it(`verifies ${number}`, () => {
+          const result = verifyRoundTrip(systemId, number);
+          expect(result.passed).toBe(true);
+          expect(result.parsed).toBe(number);
+        });
+      }
+    });
+  }
+});
+
+describe('verifyRoundTrip edge cases', () => {
+  it('returns error for unknown system', () => {
+    const result = verifyRoundTrip('unknown', 42);
+    expect(result.passed).toBe(false);
+    expect(result.error).toBe('Unknown system');
+  });
+
+  it('returns error for out-of-range number', () => {
+    const result = verifyRoundTrip('roman', 5000);
+    expect(result.passed).toBe(false);
+    expect(result.error).toBe('Out of range');
+  });
+});

--- a/src/data/showcaseExamples.js
+++ b/src/data/showcaseExamples.js
@@ -1,0 +1,65 @@
+/**
+ * Curated showcase examples per number system.
+ * Each example highlights a specific mathematical property or teaching moment.
+ */
+const showcaseExamples = {
+  mayan: [
+    { number: 0, highlight: 'One of the earliest explicit zero symbols in history', concept: 'zero' },
+    { number: 19, highlight: 'Largest single-position value — four dots over three bars', concept: 'max-digit' },
+    { number: 20, highlight: 'Base-20 rollover — zero in the ones, one in the twenties', concept: 'base-rollover' },
+    { number: 399, highlight: 'Largest two-position number (19×20 + 19)', concept: 'position-max' },
+    { number: 400, highlight: 'Third position opens — 1×20² shows powers of twenty', concept: 'higher-position' },
+    { number: 7999, highlight: 'Three full positions, each showing 19', concept: 'full-positions' },
+  ],
+  egyptian: [
+    { number: 1, highlight: 'A single stroke — the simplest hieroglyphic numeral', concept: 'unit' },
+    { number: 9, highlight: 'Nine strokes: the maximum repetition before a new symbol', concept: 'repetition-limit' },
+    { number: 10, highlight: 'The heel bone glyph replaces ten strokes', concept: 'symbol-transition' },
+    { number: 111, highlight: 'One of each: rope coil + heel bone + stroke', concept: 'additive' },
+    { number: 5555, highlight: 'Five of each symbol through the thousands — pure addition', concept: 'full-additive' },
+    { number: 1234567, highlight: 'All seven hieroglyphs used — from stroke to kneeling god Heh', concept: 'full-symbol-set' },
+  ],
+  babylonian: [
+    { number: 1, highlight: 'A single unit wedge — the foundation of cuneiform math', concept: 'unit' },
+    { number: 59, highlight: 'Largest single-position value — five ten-wedges plus nine units', concept: 'max-digit' },
+    { number: 60, highlight: 'Base-60 rollover — one group of 60, zero in the ones', concept: 'base-rollover' },
+    { number: 61, highlight: 'Two positions: 1×60 + 1 — distinguishing 61 from 2', concept: 'positional' },
+    { number: 3600, highlight: 'Third position: 1×60² — reaching into the thousands', concept: 'higher-position' },
+    { number: 3661, highlight: 'All three positions active: 1×3600 + 1×60 + 1', concept: 'full-positions' },
+  ],
+  roman: [
+    { number: 4, highlight: 'IV — the first subtractive pair (5 minus 1)', concept: 'subtraction' },
+    { number: 9, highlight: 'IX — subtractive pair at the ones place', concept: 'subtraction' },
+    { number: 49, highlight: 'XLIX — compound subtraction at two levels', concept: 'compound-subtraction' },
+    { number: 400, highlight: 'CD — subtractive pair in the hundreds', concept: 'subtraction-hundreds' },
+    { number: 900, highlight: 'CM — the largest subtractive pair', concept: 'max-subtraction' },
+    { number: 1994, highlight: 'MCMXCIV — uses three subtractive pairs in one number', concept: 'all-subtractive' },
+    { number: 3999, highlight: 'MMMCMXCIX — the maximum representable Roman numeral', concept: 'system-max' },
+  ],
+  chineseRod: [
+    { number: 5, highlight: 'A single horizontal bar — vertical orientation for ones place', concept: 'orientation' },
+    { number: 50, highlight: 'Horizontal orientation for tens place — showing alternation', concept: 'alternation' },
+    { number: 505, highlight: 'Zero placeholder between matching digits', concept: 'zero-placeholder' },
+    { number: 6789, highlight: 'Alternating vertical-horizontal-vertical-horizontal across four places', concept: 'full-alternation' },
+    { number: 12345, highlight: 'All five positions active — full decimal positional display', concept: 'five-positions' },
+  ],
+  greekAttic: [
+    { number: 1, highlight: 'A single vertical stroke (Ι) — the simplest glyph', concept: 'unit' },
+    { number: 5, highlight: 'Pi (Π) for pente — the acrophonic principle: first letter of the word', concept: 'acrophonic' },
+    { number: 10, highlight: 'Delta (Δ) for deka — each power of ten gets its own letter', concept: 'powers' },
+    { number: 50, highlight: 'The five-ligature 𐅄 — combining "five" with "ten"', concept: 'ligature' },
+    { number: 500, highlight: 'The five-ligature 𐅅 — five times hekaton', concept: 'ligature-hundreds' },
+    { number: 5000, highlight: 'The five-ligature 𐅆 — five times khilioi', concept: 'ligature-thousands' },
+    { number: 50000, highlight: 'The five-ligature 𐅇 — the largest standard Attic numeral', concept: 'ligature-max' },
+  ],
+  quipu: [
+    { number: 1, highlight: 'Figure-eight knot (∞) — the only knot type used for "one" in the ones place', concept: 'figure-eight' },
+    { number: 5, highlight: 'Five-turn long knot in the ones place — long knots encode 2–9', concept: 'long-knot' },
+    { number: 10, highlight: 'One simple knot in the tens place — higher places use a different knot type', concept: 'simple-knot' },
+    { number: 100, highlight: 'Zero gap in the tens, one knot in hundreds — absence means zero', concept: 'zero-gap' },
+    { number: 305, highlight: 'Zeros between non-zero positions — physical gaps on the cord carry meaning', concept: 'zero-placeholder' },
+    { number: 12345, highlight: 'All five positions occupied — a full positional decimal on a single cord', concept: 'full-positions' },
+  ],
+};
+
+export default showcaseExamples;

--- a/src/index.css
+++ b/src/index.css
@@ -39,3 +39,50 @@ input[type="number"] {
 .animate-stepReveal {
   opacity: 0;
 }
+
+/* Modal entrance animation */
+@keyframes modalIn {
+  from { opacity: 0; transform: scale(0.95) translateY(10px); }
+  to { opacity: 1; transform: scale(1) translateY(0); }
+}
+.animate-modalIn {
+  animation: modalIn 0.2s ease-out;
+}
+
+/* Print styles */
+@media print {
+  /* Hide navigation, footer, buttons */
+  button, footer, [data-action], input, select, textarea,
+  #number-input-container, .flex.justify-center.gap-3.mb-6 {
+    display: none !important;
+  }
+
+  /* Show showcase cards and tabs header */
+  #showcase-view, .showcase-card, #tabs-container {
+    display: block !important;
+  }
+  #tabs-container button { display: none !important; }
+  #tabs-container { margin-bottom: 1rem; }
+
+  /* Avoid page breaks inside cards */
+  .print-avoid-break {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Clean backgrounds for printing */
+  body, .bg-gradient-to-b, .bg-parchment, .bg-parchment-dark {
+    background: white !important;
+    background-image: none !important;
+  }
+  .showcase-card {
+    border: 1px solid #ccc !important;
+    margin-bottom: 0.75rem;
+    padding: 0.75rem;
+  }
+
+  /* Show verify badges in print */
+  .showcase-card span[class*="rounded-full"] {
+    display: inline-flex !important;
+  }
+}

--- a/src/store.js
+++ b/src/store.js
@@ -4,6 +4,7 @@ let state = {
   showCompare: false,
   reverseMode: false,
   showQuiz: false,
+  showShowcase: false,
 };
 
 const listeners = [];

--- a/src/utils/verification.js
+++ b/src/utils/verification.js
@@ -1,0 +1,55 @@
+import numberSystems from '../data/numberSystems.js';
+import { parseRoman } from '../converters/parsers/roman.js';
+import { parseEgyptian } from '../converters/parsers/egyptian.js';
+import { parseBabylonian } from '../converters/parsers/babylonian.js';
+import { parseMayan } from '../converters/parsers/mayan.js';
+import { parseChineseRod } from '../converters/parsers/chineseRod.js';
+import { parseGreekAttic } from '../converters/parsers/greekAttic.js';
+import { parseQuipu } from '../converters/parsers/quipu.js';
+
+const parsers = {
+  roman: { parse: parseRoman, inputType: 'text' },
+  greekAttic: { parse: parseGreekAttic, inputType: 'text' },
+  egyptian: { parse: parseEgyptian, inputType: 'symbols' },
+  babylonian: { parse: parseBabylonian, inputType: 'groups' },
+  mayan: { parse: parseMayan, inputType: 'symbols' },
+  chineseRod: { parse: parseChineseRod, inputType: 'symbols' },
+  quipu: { parse: parseQuipu, inputType: 'symbols' },
+};
+
+/**
+ * Verify a round-trip conversion: decimal → ancient → parse back → compare.
+ * Returns { passed, original, parsed, error }
+ */
+export function verifyRoundTrip(systemId, number) {
+  const system = numberSystems[systemId];
+  const parser = parsers[systemId];
+  if (!system || !parser) {
+    return { passed: false, original: number, parsed: null, error: 'Unknown system' };
+  }
+
+  const { result } = system.convert(number);
+  if (result[0] === 'Invalid input') {
+    return { passed: false, original: number, parsed: null, error: 'Out of range' };
+  }
+
+  let parseResult;
+  if (parser.inputType === 'text') {
+    // Roman and Greek Attic wrap result in a single-element array
+    parseResult = parser.parse(result[0]);
+  } else if (parser.inputType === 'groups') {
+    parseResult = parser.parse(result);
+  } else {
+    // Mayan and Quipu converters store bottom-to-top (ones first); parsers expect top-to-bottom
+    const input = (system.renderMode === 'vertical' || system.renderMode === 'cord')
+      ? [...result].reverse() : result;
+    parseResult = parser.parse(input);
+  }
+
+  if (parseResult.error) {
+    return { passed: false, original: number, parsed: null, error: parseResult.error };
+  }
+
+  const passed = parseResult.value === number;
+  return { passed, original: number, parsed: parseResult.value, error: passed ? null : 'Mismatch' };
+}


### PR DESCRIPTION
## Summary

- **Showcase mode** — new third nav button displaying curated educational walkthroughs per number system (all 7 including Quipu) with round-trip verification badges, step breakdowns, and historical context
- **Verify button** on Converter mode runs inline round-trip checks (decimal → ancient → parse → compare)
- **Report Issue** modal with auto-filled context, stored in localStorage with view/export panel via footer link
- **Print** and **Copy as Text** export for classroom use
- 45 new verification tests covering all showcase examples across all 7 systems (284 total)

## Test plan

- [x] `npm test` — 284 tests passing
- [x] `npm run build` — clean production build
- [ ] Verify Showcase mode renders for all 7 systems with green badges
- [ ] Verify tab switching works in Showcase mode
- [ ] Verify Print button triggers print dialog
- [ ] Verify Copy as Text copies serialized walkthrough
- [ ] Verify inline Verify button shows round-trip result in Converter mode
- [ ] Verify Report modal opens with auto-filled context, submits to localStorage
- [ ] Verify Submitted Reports panel shows/deletes/exports entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)