### PR TITLE
Fix Mayan volume control mobile UX: audio unlock and drop zone visibility

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -46,11 +46,17 @@ input[type="number"] {
 }
 .vol-drop-active {
   border-color: #2D6A4F !important;
-  box-shadow: 0 0 12px rgba(45, 106, 79, 0.3);
+  border-style: solid !important;
+  border-width: 3px !important;
+  box-shadow: 0 0 16px rgba(45, 106, 79, 0.4), inset 0 0 12px rgba(45, 106, 79, 0.1);
+  background-color: rgba(45, 106, 79, 0.08) !important;
 }
 .vol-drop-reject {
   border-color: #f87171 !important;
-  box-shadow: 0 0 12px rgba(248, 113, 113, 0.3);
+  border-style: solid !important;
+  border-width: 3px !important;
+  box-shadow: 0 0 16px rgba(248, 113, 113, 0.4), inset 0 0 12px rgba(248, 113, 113, 0.1);
+  background-color: rgba(248, 113, 113, 0.06) !important;
 }
 .vol-dragging {
   opacity: 0.5;
@@ -67,7 +73,42 @@ input[type="number"] {
 .vol-zone-target {
   animation: zoneTargetPulse 1.2s ease-in-out infinite;
   border-color: rgba(45, 106, 79, 0.5) !important;
+  border-style: solid !important;
+  border-width: 3px !important;
 }
+/* Touch drag clone — large, visible, centered under finger */
+.vol-touch-clone {
+  position: fixed;
+  pointer-events: none;
+  z-index: 50;
+  opacity: 0.9;
+  transform: scale(1.3);
+  filter: drop-shadow(0 4px 12px rgba(0,0,0,0.25));
+  border-radius: 0.75rem;
+  background: rgba(255,255,255,0.9);
+  padding: 4px 8px;
+}
+
+/* "Drop here" shimmer shown on zones during active touch drag */
+.vol-zone-drag-hint {
+  border-color: rgba(45, 106, 79, 0.5) !important;
+  border-style: solid !important;
+}
+.vol-zone-drag-hint::after {
+  content: '\2193  Drop here';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(45, 106, 79, 0.5);
+  pointer-events: none;
+}
+
 .vol-confetti {
   position: absolute;
   bottom: 50%;

--- a/src/volume/volume-app.js
+++ b/src/volume/volume-app.js
@@ -1,6 +1,6 @@
 import { renderVolumePage, renderLevelPieces, renderLevel, renderDecimalReadout, renderControls, renderVolumeMeter, renderTooLoudOverlay } from './volume-render.js';
 import { getRandomTagline, getDangerLevel, triggerShake, triggerConfetti, getMeterGradient, getGlowShadow } from './volume-effects.js';
-import { initAudio, play, stop, setVolume } from './volume-audio.js';
+import { initAudio, play, stop, setVolume, unlockAudio } from './volume-audio.js';
 import { decompose } from './volume-render.js';
 
 // ── Constants ──────────────────────────────────
@@ -192,6 +192,17 @@ function canAdd(levelIdx, piece) {
 function setupEvents() {
   const root = document.getElementById('vol-root');
 
+  // Unlock mobile audio on the very first user gesture (tap or click anywhere).
+  // iOS Safari and Chrome Android suspend the AudioContext until a user gesture
+  // plays audio. We do this once, as early as possible.
+  function onFirstInteraction() {
+    unlockAudio();
+    root.removeEventListener('touchstart', onFirstInteraction);
+    root.removeEventListener('click', onFirstInteraction);
+  }
+  root.addEventListener('touchstart', onFirstInteraction, { passive: true });
+  root.addEventListener('click', onFirstInteraction);
+
   // Desktop DnD
   root.addEventListener('dragstart', (e) => {
     const token = e.target.closest('[data-piece]');
@@ -270,9 +281,11 @@ function setupEvents() {
       selectedPiece = null;
       updatePaletteSelection();
       touchClone = touchSourceEl.cloneNode(true);
-      touchClone.className = 'fixed pointer-events-none z-50 opacity-80 scale-110';
+      touchClone.className = 'vol-touch-clone';
       touchClone.style.transition = 'none';
       document.body.appendChild(touchClone);
+      // Show "drop here" labels on all zones during drag
+      root.querySelectorAll('[data-level]').forEach(z => z.classList.add('vol-zone-drag-hint'));
     }
 
     e.preventDefault();
@@ -321,8 +334,8 @@ function setupEvents() {
     touchClone = null;
     touchPiece = null;
     touchSourceEl = null;
-    root.querySelectorAll('.vol-drop-active, .vol-drop-reject').forEach((el) => {
-      el.classList.remove('vol-drop-active', 'vol-drop-reject');
+    root.querySelectorAll('.vol-drop-active, .vol-drop-reject, .vol-zone-drag-hint').forEach((el) => {
+      el.classList.remove('vol-drop-active', 'vol-drop-reject', 'vol-zone-drag-hint');
     });
   });
 

--- a/src/volume/volume-audio.js
+++ b/src/volume/volume-audio.js
@@ -1,6 +1,7 @@
 let audioCtx = null;
 let gainNode = null;
 let sourceNodes = [];
+let unlocked = false;
 
 export function initAudio() {
   if (audioCtx) return;
@@ -13,6 +14,25 @@ function ensureResumed() {
   if (audioCtx && audioCtx.state === 'suspended') {
     audioCtx.resume();
   }
+}
+
+/**
+ * Call this on the first user gesture (tap/click anywhere) to unlock
+ * audio playback on mobile browsers. iOS Safari and Chrome on Android
+ * require a user-initiated audio context resume + silent buffer play
+ * before real audio will work.
+ */
+export function unlockAudio() {
+  if (unlocked) return;
+  initAudio();
+  ensureResumed();
+  // Play a silent buffer to fully unlock the audio pipeline on iOS
+  const silent = audioCtx.createBuffer(1, 1, audioCtx.sampleRate);
+  const src = audioCtx.createBufferSource();
+  src.buffer = silent;
+  src.connect(audioCtx.destination);
+  src.start();
+  unlocked = true;
 }
 
 function stopSources() {

--- a/src/volume/volume-render.js
+++ b/src/volume/volume-render.js
@@ -46,8 +46,13 @@ export function renderPalette() {
           </div>
         </div>
       </div>
-      <div class="text-center mt-2 text-stone-500 text-xs">
-        Tap a piece, then tap a zone
+      <div class="text-center mt-2 text-stone-500 text-xs sm:text-xs">
+        <span class="hidden sm:inline">Tap a piece, then tap a zone &mdash; or drag &amp; drop</span>
+        <span class="sm:hidden text-sm font-medium text-stone-600">
+          <span class="inline-block bg-stone-300/60 rounded px-1.5 py-0.5 mr-1">1</span>Tap a piece
+          <span class="mx-1.5 text-stone-400">&rarr;</span>
+          <span class="inline-block bg-stone-300/60 rounded px-1.5 py-0.5 mr-1">2</span>Tap a zone below
+        </span>
       </div>
     </div>`;
 }
@@ -60,9 +65,10 @@ export function decompose(value) {
 function renderPieces(value) {
   const { bars, dots, isZero } = decompose(value);
   if (isZero) {
-    return `<div class="flex flex-col items-center justify-center h-full py-3 gap-1">
+    return `<div class="flex flex-col items-center justify-center h-full py-4 gap-1.5">
       <span class="text-3xl text-stone-400">&#x1D330;</span>
-      <span class="text-[10px] text-stone-500 uppercase tracking-wider">Tap or drop pieces here</span>
+      <span class="text-xs sm:text-[10px] text-stone-500 font-medium uppercase tracking-wider">Drop here</span>
+      <span class="text-[10px] text-stone-400 sm:hidden">&darr; Tap a piece above, then tap this zone</span>
     </div>`;
   }
 
@@ -107,7 +113,8 @@ export function renderLevel(position, value) {
   const emptyClass = value === 0 ? ' vol-zone-empty' : '';
   return `
     <div data-level="${position}"
-         class="vol-drop-zone bg-stone-200/60 border-2 border-dashed border-stone-400 rounded-xl p-4 min-h-[130px]
+         class="vol-drop-zone bg-stone-200/60 border-2 border-dashed border-stone-400 rounded-xl
+                p-4 min-h-[130px] sm:min-h-[130px]
                 relative transition-all duration-200 shadow-md hover:border-stone-500${emptyClass}">
       <div class="flex items-center justify-between mb-1">
         <div class="flex items-center gap-2">


### PR DESCRIPTION
Mobile browsers (iOS Safari, Chrome Android) suspend AudioContext until a
user gesture plays audio. Added an unlockAudio() function that creates the
context, resumes it, and plays a silent buffer on the very first tap/click
anywhere on the page, so subsequent autoplay on piece drop works reliably.

Improved drop zone discoverability on mobile:
- Clearer step-by-step instruction banner ("1 Tap a piece -> 2 Tap a zone")
- Larger "Drop here" label in empty zones with mobile-only helper text
- Zones switch from dashed to solid 3px borders when targeted or active
- Enhanced drop-active/reject styles with background tint and inset glow
- During touch drag, zones show a "Drop here" overlay via ::after pseudo
- Touch drag clone styled with drop-shadow, white background, and 1.3x scale

https://claude.ai/code/session_01HMKYqxtu9cTAJwvPcmvqpQ