### PR TITLE
Replace misleading taglines in volume demo with obviously humorous ones

### DIFF
--- a/src/volume/volume-effects.js
+++ b/src/volume/volume-effects.js
@@ -6,10 +6,10 @@ const TAGLINES = [
   'Now with 400% More Range Than You Need',
   'Enterprise-Grade Ancient Technology',
   'Mathematically Accurate Volume',
-  'Approved by the Long Count Calendar Board',
+  'May Cause Spontaneous Pyramid Construction',
   'Carbon-Dated Audio Fidelity',
-  'Peer-Reviewed by Mesoamerican Scholars',
-  'ISO 20:20 Compliant',
+  'Caution: Contains Trace Amounts of Obsidian',
+  'Pairs Well with Cacao',
   'Not Responsible for Jaguar Summons',
 ];
 


### PR DESCRIPTION
Removed three taglines that could be mistaken for real endorsements:
- "Approved by the Long Count Calendar Board"
- "Peer-Reviewed by Mesoamerican Scholars"
- "ISO 20:20 Compliant"

Replaced with clearly absurd alternatives that stay on theme.

https://claude.ai/code/session_01TMud7eJtztUWkfGBWbXiL4